### PR TITLE
Fix typo in tfx.orchestration.config.PipelineConfig docstring

### DIFF
--- a/tfx/orchestration/config/pipeline_config.py
+++ b/tfx/orchestration/config/pipeline_config.py
@@ -28,7 +28,7 @@ from tfx.orchestration.launcher import in_process_component_launcher
 class PipelineConfig(object):
   """Config class which controls how to run a pipeline.
 
-  Attributes
+  Attributes:
     supported_launcher_classes: A list of component launcher classes that are
       supported by the current pipeline. List sequence determines the order in
       which launchers are chosen for each component being run.


### PR DESCRIPTION
The current docstring is missing a `:` char, which prevents its proper parsing and formatting in the docs: https://www.tensorflow.org/tfx/api_docs/python/tfx/orchestration/config/pipeline_config/PipelineConfig